### PR TITLE
[HQT-76] Observation typechecking for agent call

### DIFF
--- a/packages/components/src/agents.ts
+++ b/packages/components/src/agents.ts
@@ -449,7 +449,7 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
                             return { action, observation: observation ?? '' }
                         }
                     }
-                    if (observation?.includes(SOURCE_DOCUMENTS_PREFIX)) {
+                    if (typeof observation === 'string' && observation?.includes(SOURCE_DOCUMENTS_PREFIX)) {
                         const observationArray = observation.split(SOURCE_DOCUMENTS_PREFIX)
                         observation = observationArray[0]
                         const docs = observationArray[1]
@@ -558,7 +558,7 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
                             input: this.input
                         }
                     )
-                    if (observation?.includes(SOURCE_DOCUMENTS_PREFIX)) {
+                    if (typeof observation === 'string' && observation?.includes(SOURCE_DOCUMENTS_PREFIX)) {
                         const observationArray = observation.split(SOURCE_DOCUMENTS_PREFIX)
                         observation = observationArray[0]
                     }


### PR DESCRIPTION
**DESCRIPTION**
- Fix issue where JSON Object returned by agent is causing error
- Check whether observation type is string or no for getting document source returned by tool
- This PR will allow tool return JSON object directly

**SCREENSHOT / RECORDING DEMO**
- The issue before
![image](https://github.com/jasontjahjono/flowise/assets/71967041/1bae1252-33e4-453b-884d-f3e7a339e415)
- Resolved issue
![image](https://github.com/jasontjahjono/flowise/assets/71967041/1754a224-0e96-431f-88bd-0d0404caec16)
