### PR TITLE
[HQT-115] Integrate output parser with API Chain

### DIFF
--- a/packages/components/nodes/chains/ParsedAPIChain/ParsedGETApiChain.ts
+++ b/packages/components/nodes/chains/ParsedAPIChain/ParsedGETApiChain.ts
@@ -1,0 +1,156 @@
+import { BaseLanguageModel } from '@langchain/core/language_models/base'
+import { PromptTemplate } from '@langchain/core/prompts'
+import { API_RESPONSE_RAW_PROMPT_TEMPLATE, API_URL_RAW_PROMPT_TEMPLATE, APIChain } from './getCore'
+import { ConsoleCallbackHandler, CustomChainHandler, additionalCallbacks } from '../../../src/handler'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses } from '../../../src/utils'
+import { BaseLLMOutputParser, BaseOutputParser } from '@langchain/core/output_parsers'
+import { OutputFixingParser } from 'langchain/output_parsers'
+
+class ParsedGETApiChain_Chains implements INode {
+    label: string
+    name: string
+    version: number
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    description: string
+    inputs: INodeParams[]
+    outputParser: BaseLLMOutputParser
+
+    constructor() {
+        this.label = 'Parsed GET API Chain'
+        this.name = 'ParsedgetApiChain'
+        this.version = 1.0
+        this.type = 'ParsedGETApiChain'
+        this.icon = 'get.svg'
+        this.category = 'Chains'
+        this.description = 'Output Parser Integrated-Chain to run queries against GET API'
+        this.baseClasses = [this.type, ...getBaseClasses(APIChain)]
+        this.inputs = [
+            {
+                label: 'Language Model',
+                name: 'model',
+                type: 'BaseLanguageModel'
+            },
+            {
+                label: 'Output Parser',
+                name: 'outputParser',
+                type: 'BaseLLMOutputParser',
+                optional: true
+            },
+            {
+                label: 'API Documentation',
+                name: 'apiDocs',
+                type: 'string',
+                description:
+                    'Description of how API works. Please refer to more <a target="_blank" href="https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/chains/api/open_meteo_docs.py">examples</a>',
+                rows: 4
+            },
+            {
+                label: 'Headers',
+                name: 'headers',
+                type: 'json',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'URL Prompt',
+                name: 'urlPrompt',
+                type: 'string',
+                description: 'Prompt used to tell LLMs how to construct the URL. Must contains {api_docs} and {question}',
+                default: API_URL_RAW_PROMPT_TEMPLATE,
+                rows: 4,
+                additionalParams: true
+            },
+            {
+                label: 'Answer Prompt',
+                name: 'ansPrompt',
+                type: 'string',
+                description:
+                    'Prompt used to tell LLMs how to return the API response. Must contains {api_response}, {api_url}, and {question}',
+                default: API_RESPONSE_RAW_PROMPT_TEMPLATE,
+                rows: 4,
+                additionalParams: true
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData): Promise<any> {
+        const model = nodeData.inputs?.model as BaseLanguageModel
+        const apiDocs = nodeData.inputs?.apiDocs as string
+        const headers = nodeData.inputs?.headers as string
+        const urlPrompt = nodeData.inputs?.urlPrompt as string
+        const ansPrompt = nodeData.inputs?.ansPrompt as string
+        const outputParser = nodeData.inputs?.outputParser as BaseLLMOutputParser
+
+        if (outputParser) {
+            let autoFix = (outputParser as any).autoFix
+            if (autoFix === true) {
+                this.outputParser = OutputFixingParser.fromLLM(model, outputParser as BaseOutputParser)
+            } else {
+                this.outputParser = outputParser
+            }
+        }
+
+        const chain = await getAPIChain(apiDocs, model, outputParser as BaseOutputParser, headers, urlPrompt, ansPrompt)
+        return chain
+    }
+
+    async run(nodeData: INodeData, input: string, options: ICommonObject): Promise<string | object> {
+        const model = nodeData.inputs?.model as BaseLanguageModel
+        const apiDocs = nodeData.inputs?.apiDocs as string
+        const headers = nodeData.inputs?.headers as string
+        const urlPrompt = nodeData.inputs?.urlPrompt as string
+        const ansPrompt = nodeData.inputs?.ansPrompt as string
+        const outputParser = nodeData.inputs?.outputParser as BaseLLMOutputParser
+
+        const chain = await getAPIChain(apiDocs, model, outputParser, headers, urlPrompt, ansPrompt)
+        const loggerHandler = new ConsoleCallbackHandler(options.logger)
+        const callbacks = await additionalCallbacks(nodeData, options)
+
+        if (!this.outputParser && outputParser) {
+            this.outputParser = outputParser
+        }
+
+        if (options.socketIO && options.socketIOClientId) {
+            const handler = new CustomChainHandler(options.socketIO, options.socketIOClientId, 2)
+            const res = await chain.run(input, [loggerHandler, handler, ...callbacks])
+            return res
+        } else {
+            const res = await chain.run(input, [loggerHandler, ...callbacks])
+            return res
+        }
+    }
+}
+
+const getAPIChain = async (
+    documents: string,
+    llm: BaseLanguageModel,
+    outputParser: BaseLLMOutputParser,
+    headers: string,
+    urlPrompt: string,
+    ansPrompt: string
+) => {
+    const apiUrlPrompt = new PromptTemplate({
+        inputVariables: ['api_docs', 'question'],
+        template: urlPrompt ? urlPrompt : API_URL_RAW_PROMPT_TEMPLATE
+    })
+
+    const apiResponsePrompt = new PromptTemplate({
+        inputVariables: ['api_docs', 'question', 'api_url_body', 'api_response'],
+        template: ansPrompt ? ansPrompt : API_RESPONSE_RAW_PROMPT_TEMPLATE
+    })
+
+    const chain = APIChain.fromLLMAndAPIDocs(llm, documents, {
+        apiUrlPrompt,
+        apiResponsePrompt,
+        verbose: process.env.DEBUG === 'true' ? true : false,
+        headers: typeof headers === 'object' ? headers : headers ? JSON.parse(headers) : {},
+        outputParser
+    })
+    return chain
+}
+
+module.exports = { nodeClass: ParsedGETApiChain_Chains }

--- a/packages/components/nodes/chains/ParsedAPIChain/ParsedPOSTApiChain.ts
+++ b/packages/components/nodes/chains/ParsedAPIChain/ParsedPOSTApiChain.ts
@@ -1,0 +1,156 @@
+import { BaseLanguageModel } from '@langchain/core/language_models/base'
+import { PromptTemplate } from '@langchain/core/prompts'
+import { API_RESPONSE_RAW_PROMPT_TEMPLATE, API_URL_RAW_PROMPT_TEMPLATE, APIChain } from './postCore'
+import { ConsoleCallbackHandler, CustomChainHandler, additionalCallbacks } from '../../../src/handler'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses } from '../../../src/utils'
+import { BaseLLMOutputParser, BaseOutputParser } from '@langchain/core/output_parsers'
+import { OutputFixingParser } from 'langchain/output_parsers'
+
+class ParsedPOSTApiChain_Chains implements INode {
+    label: string
+    name: string
+    version: number
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    description: string
+    inputs: INodeParams[]
+    outputParser: BaseLLMOutputParser
+
+    constructor() {
+        this.label = 'Parsed POST API Chain'
+        this.name = 'ParsedpostApiChain'
+        this.version = 1.0
+        this.type = 'ParsedPOSTApiChain'
+        this.icon = 'post.svg'
+        this.category = 'Chains'
+        this.description = 'Output Parser Integrated-Chain to run queries against POST API'
+        this.baseClasses = [this.type, ...getBaseClasses(APIChain)]
+        this.inputs = [
+            {
+                label: 'Language Model',
+                name: 'model',
+                type: 'BaseLanguageModel'
+            },
+            {
+                label: 'Output Parser',
+                name: 'outputParser',
+                type: 'BaseLLMOutputParser',
+                optional: true
+            },
+            {
+                label: 'API Documentation',
+                name: 'apiDocs',
+                type: 'string',
+                description:
+                    'Description of how API works. Please refer to more <a target="_blank" href="https://github.com/langchain-ai/langchain/blob/master/libs/langchain/langchain/chains/api/open_meteo_docs.py">examples</a>',
+                rows: 4
+            },
+            {
+                label: 'Headers',
+                name: 'headers',
+                type: 'json',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'URL Prompt',
+                name: 'urlPrompt',
+                type: 'string',
+                description: 'Prompt used to tell LLMs how to construct the URL. Must contains {api_docs} and {question}',
+                default: API_URL_RAW_PROMPT_TEMPLATE,
+                rows: 4,
+                additionalParams: true
+            },
+            {
+                label: 'Answer Prompt',
+                name: 'ansPrompt',
+                type: 'string',
+                description:
+                    'Prompt used to tell LLMs how to return the API response. Must contains {api_response}, {api_url}, and {question}',
+                default: API_RESPONSE_RAW_PROMPT_TEMPLATE,
+                rows: 4,
+                additionalParams: true
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData): Promise<any> {
+        const model = nodeData.inputs?.model as BaseLanguageModel
+        const apiDocs = nodeData.inputs?.apiDocs as string
+        const headers = nodeData.inputs?.headers as string
+        const urlPrompt = nodeData.inputs?.urlPrompt as string
+        const ansPrompt = nodeData.inputs?.ansPrompt as string
+        const outputParser = nodeData.inputs?.outputParser as BaseLLMOutputParser
+
+        if (outputParser) {
+            let autoFix = (outputParser as any).autoFix
+            if (autoFix === true) {
+                this.outputParser = OutputFixingParser.fromLLM(model, outputParser as BaseOutputParser)
+            } else {
+                this.outputParser = outputParser
+            }
+        }
+
+        const chain = await getAPIChain(apiDocs, model, outputParser as BaseOutputParser, headers, urlPrompt, ansPrompt)
+        return chain
+    }
+
+    async run(nodeData: INodeData, input: string, options: ICommonObject): Promise<string | object> {
+        const model = nodeData.inputs?.model as BaseLanguageModel
+        const apiDocs = nodeData.inputs?.apiDocs as string
+        const headers = nodeData.inputs?.headers as string
+        const urlPrompt = nodeData.inputs?.urlPrompt as string
+        const ansPrompt = nodeData.inputs?.ansPrompt as string
+        const outputParser = nodeData.inputs?.outputParser as BaseLLMOutputParser
+
+        const chain = await getAPIChain(apiDocs, model, outputParser, headers, urlPrompt, ansPrompt)
+        const loggerHandler = new ConsoleCallbackHandler(options.logger)
+        const callbacks = await additionalCallbacks(nodeData, options)
+
+        if (!this.outputParser && outputParser) {
+            this.outputParser = outputParser
+        }
+
+        if (options.socketIO && options.socketIOClientId) {
+            const handler = new CustomChainHandler(options.socketIO, options.socketIOClientId, 2)
+            const res = await chain.run(input, [loggerHandler, handler, ...callbacks])
+            return res
+        } else {
+            const res = await chain.run(input, [loggerHandler, ...callbacks])
+            return res
+        }
+    }
+}
+
+const getAPIChain = async (
+    documents: string,
+    llm: BaseLanguageModel,
+    outputParser: BaseLLMOutputParser,
+    headers: string,
+    urlPrompt: string,
+    ansPrompt: string
+) => {
+    const apiUrlPrompt = new PromptTemplate({
+        inputVariables: ['api_docs', 'question'],
+        template: urlPrompt ? urlPrompt : API_URL_RAW_PROMPT_TEMPLATE
+    })
+
+    const apiResponsePrompt = new PromptTemplate({
+        inputVariables: ['api_docs', 'question', 'api_url_body', 'api_response'],
+        template: ansPrompt ? ansPrompt : API_RESPONSE_RAW_PROMPT_TEMPLATE
+    })
+
+    const chain = APIChain.fromLLMAndAPIDocs(llm, documents, {
+        apiUrlPrompt,
+        apiResponsePrompt,
+        verbose: process.env.DEBUG === 'true' ? true : false,
+        headers: typeof headers === 'object' ? headers : headers ? JSON.parse(headers) : {},
+        outputParser
+    })
+    return chain
+}
+
+module.exports = { nodeClass: ParsedPOSTApiChain_Chains }

--- a/packages/components/nodes/chains/ParsedAPIChain/get.svg
+++ b/packages/components/nodes/chains/ParsedAPIChain/get.svg
@@ -1,0 +1,7 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.5 20.5C10.5 20.5 10 20 9 20C7.067 20 6 21.567 6 23.5C6 25.433 7.067 27 9 27C10 27 10.7037 26.4812 11 26V24H10" stroke="#110000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.5 20H14V27H18.5M14 23.5H17.5" stroke="black" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M23.5 27V20M21 20H26" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19 10C19 6.68629 16.2577 4 12.875 4H11.125C7.74226 4 5 6.68629 5 10C5 11.7572 5.77114 13.338 7 14.4353" stroke="black" stroke-width="2" stroke-linecap="round"/>
+<path d="M13 9C13 12.3137 15.7423 15 19.125 15H20.875C24.2577 15 27 12.3137 27 9C27 5.68629 24.2577 3 20.875 3" stroke="black" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/packages/components/nodes/chains/ParsedAPIChain/getCore.ts
+++ b/packages/components/nodes/chains/ParsedAPIChain/getCore.ts
@@ -1,0 +1,167 @@
+import { BaseLanguageModel } from '@langchain/core/language_models/base'
+import { CallbackManagerForChainRun } from '@langchain/core/callbacks/manager'
+import { BaseChain, ChainInputs, LLMChain, SerializedAPIChain } from 'langchain/chains'
+import { BasePromptTemplate, PromptTemplate } from '@langchain/core/prompts'
+import { ChainValues } from '@langchain/core/utils/types'
+import fetch from 'node-fetch'
+import { BaseLLMOutputParser } from '@langchain/core/output_parsers'
+
+export const API_URL_RAW_PROMPT_TEMPLATE = `You are given the below API Documentation:
+{api_docs}
+Using this documentation, generate a json string with key: "url"
+The value of "url" should be a string, which is the API url, including its params to call for answering the user question.
+Be careful to always use double quotes for strings in the json string.
+You should build the json string in order to get a response that is as short as possible, while still getting the necessary information to answer the question. Pay attention to deliberately exclude any unnecessary pieces of data in the API call.
+
+Question:{question}
+json string:`
+
+export const API_RESPONSE_RAW_PROMPT_TEMPLATE = `given this {api_response} response for {api_url_body}
+
+Summarize this response to answer the original question.
+
+Summary:`
+
+const defaultApiUrlPrompt = new PromptTemplate({
+    inputVariables: ['api_docs', 'question'],
+    template: API_URL_RAW_PROMPT_TEMPLATE
+})
+
+const defaultApiResponsePrompt = new PromptTemplate({
+    inputVariables: ['api_docs', 'question', 'api_url_body', 'api_response'],
+    template: API_RESPONSE_RAW_PROMPT_TEMPLATE
+})
+
+export interface APIChainInput extends Omit<ChainInputs, 'memory'> {
+    apiAnswerChain: LLMChain<string | object>
+    apiRequestChain: LLMChain
+    apiDocs: string
+    inputKey?: string
+    headers?: Record<string, string>
+    /** Key to use for output, defaults to `output` */
+    outputKey?: string
+}
+
+export type APIChainOptions = {
+    headers?: Record<string, string>
+    apiUrlPrompt?: BasePromptTemplate
+    apiResponsePrompt?: BasePromptTemplate
+    outputParser?: BaseLLMOutputParser
+}
+
+export class APIChain extends BaseChain implements APIChainInput {
+    apiAnswerChain: LLMChain<string | object>
+
+    apiRequestChain: LLMChain
+
+    apiDocs: string
+
+    headers = {}
+
+    inputKey = 'question'
+
+    outputKey = 'output'
+
+    get inputKeys() {
+        return [this.inputKey]
+    }
+
+    get outputKeys() {
+        return [this.outputKey]
+    }
+
+    constructor(fields: APIChainInput) {
+        super(fields)
+        this.apiRequestChain = fields.apiRequestChain
+        this.apiAnswerChain = fields.apiAnswerChain
+        this.apiDocs = fields.apiDocs
+        this.inputKey = fields.inputKey ?? this.inputKey
+        this.outputKey = fields.outputKey ?? this.outputKey
+        this.headers = fields.headers ?? this.headers
+    }
+
+    /** @ignore */
+    async _call(values: ChainValues, runManager?: CallbackManagerForChainRun): Promise<ChainValues> {
+        try {
+            const question: string = values[this.inputKey]
+
+            const api_url_body = await this.apiRequestChain.predict({ question, api_docs: this.apiDocs }, runManager?.getChild())
+
+            const { url, data } = JSON.parse(api_url_body)
+
+            const res = await fetch(url, {
+                method: 'GET',
+                headers: this.headers
+                // body: JSON.stringify(data)
+            })
+
+            const api_response = await res.text()
+
+            const answer = await this.apiAnswerChain.predict(
+                { question, api_docs: this.apiDocs, api_url_body, api_response },
+                runManager?.getChild()
+            )
+
+            return { [this.outputKey]: answer }
+        } catch (error) {
+            return { [this.outputKey]: error }
+        }
+    }
+
+    _chainType() {
+        return 'api_chain' as const
+    }
+
+    static async deserialize(data: SerializedAPIChain) {
+        const { api_request_chain, api_answer_chain, api_docs } = data
+
+        if (!api_request_chain) {
+            throw new Error('LLMChain must have api_request_chain')
+        }
+        if (!api_answer_chain) {
+            throw new Error('LLMChain must have api_answer_chain')
+        }
+        if (!api_docs) {
+            throw new Error('LLMChain must have api_docs')
+        }
+
+        return new APIChain({
+            apiAnswerChain: await LLMChain.deserialize(api_answer_chain),
+            apiRequestChain: await LLMChain.deserialize(api_request_chain),
+            apiDocs: api_docs
+        })
+    }
+
+    serialize(): SerializedAPIChain {
+        return {
+            _type: this._chainType(),
+            api_answer_chain: this.apiAnswerChain.serialize(),
+            api_request_chain: this.apiRequestChain.serialize(),
+            api_docs: this.apiDocs
+        }
+    }
+
+    static fromLLMAndAPIDocs(
+        llm: BaseLanguageModel,
+        apiDocs: string,
+        options: APIChainOptions & Omit<APIChainInput, 'apiAnswerChain' | 'apiRequestChain' | 'apiDocs'> = {}
+    ): APIChain {
+        const { apiUrlPrompt = defaultApiUrlPrompt, apiResponsePrompt = defaultApiResponsePrompt, outputParser = undefined } = options
+        const apiRequestChain = new LLMChain({ prompt: apiUrlPrompt, llm })
+        // let promptValues = apiResponsePrompt
+        // if (outputParser) {
+        //     promptValues = injectOutputParser(outputParser, apiRequestChain, apiResponsePrompt)
+        // }
+        const apiAnswerChain = new LLMChain({
+            prompt: apiResponsePrompt,
+            llm,
+            outputParser: outputParser as BaseLLMOutputParser<string | object>
+        })
+        return new this({
+            apiAnswerChain,
+            apiRequestChain,
+            apiDocs,
+            ...options
+        })
+    }
+}

--- a/packages/components/nodes/chains/ParsedAPIChain/post.svg
+++ b/packages/components/nodes/chains/ParsedAPIChain/post.svg
@@ -1,0 +1,8 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 27V20H6.5C7.60457 20 8.5 20.8954 8.5 22C8.5 23.1046 7.60457 24 6.5 24H4" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M27 27V20M25 20H29" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M22.5644 20.4399C21.6769 19.7608 19 19.6332 19 21.7961C19 24.1915 23 22.5657 23 25.0902C23 26.9875 20.33 27.5912 19 26.3537" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 23.5C11 20.7 12.6667 20 13.5 20C14.3333 20 16 20.7 16 23.5C16 26.3 14.3333 27 13.5 27C12.6667 27 11 26.3 11 23.5Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19 10C19 6.68629 16.2577 4 12.875 4H11.125C7.74226 4 5 6.68629 5 10C5 11.7572 5.77114 13.338 7 14.4353" stroke="black" stroke-width="2" stroke-linecap="round"/>
+<path d="M13 9C13 12.3137 15.7423 15 19.125 15H20.875C24.2577 15 27 12.3137 27 9C27 5.68629 24.2577 3 20.875 3" stroke="black" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/packages/components/nodes/chains/ParsedAPIChain/postCore.ts
+++ b/packages/components/nodes/chains/ParsedAPIChain/postCore.ts
@@ -1,0 +1,172 @@
+import { BaseLanguageModel } from '@langchain/core/language_models/base'
+import { CallbackManagerForChainRun } from '@langchain/core/callbacks/manager'
+import { BaseChain, ChainInputs, LLMChain, SerializedAPIChain } from 'langchain/chains'
+import { BasePromptTemplate, PromptTemplate } from '@langchain/core/prompts'
+import { ChainValues } from '@langchain/core/utils/types'
+import fetch from 'node-fetch'
+import { BaseLLMOutputParser } from '@langchain/core/output_parsers'
+
+export const API_URL_RAW_PROMPT_TEMPLATE = `You are given the below API Documentation:
+{api_docs}
+Using this documentation, generate a json string with two keys: "url" and "data".
+The value of "url" should be a string, which is the API url to call for answering the user question.
+The value of "data" should be a dictionary of key-value pairs you want to POST to the url as a JSON body.
+Be careful to always use double quotes for strings in the json string.
+You should build the json string in order to get a response that is as short as possible, while still getting the necessary information to answer the question. Pay attention to deliberately exclude any unnecessary pieces of data in the API call.
+
+Question:{question}
+json string:`
+
+export const API_RESPONSE_RAW_PROMPT_TEMPLATE = `${API_URL_RAW_PROMPT_TEMPLATE} {api_url_body}
+
+Here is the response from the API:
+
+{api_response}
+
+Summarize this response to answer the original question.
+
+Summary:`
+
+const defaultApiUrlPrompt = new PromptTemplate({
+    inputVariables: ['api_docs', 'question'],
+    template: API_URL_RAW_PROMPT_TEMPLATE
+})
+
+const defaultApiResponsePrompt = new PromptTemplate({
+    inputVariables: ['api_docs', 'question', 'api_url_body', 'api_response'],
+    template: API_RESPONSE_RAW_PROMPT_TEMPLATE
+})
+
+export interface APIChainInput extends Omit<ChainInputs, 'memory'> {
+    apiAnswerChain: LLMChain<string | object>
+    apiRequestChain: LLMChain
+    apiDocs: string
+    inputKey?: string
+    headers?: Record<string, string>
+    /** Key to use for output, defaults to `output` */
+    outputKey?: string
+}
+
+export type APIChainOptions = {
+    headers?: Record<string, string>
+    apiUrlPrompt?: BasePromptTemplate
+    apiResponsePrompt?: BasePromptTemplate
+    outputParser?: BaseLLMOutputParser
+}
+
+export class APIChain extends BaseChain implements APIChainInput {
+    apiAnswerChain: LLMChain<string | object>
+
+    apiRequestChain: LLMChain
+
+    apiDocs: string
+
+    headers = {}
+
+    inputKey = 'question'
+
+    outputKey = 'output'
+
+    get inputKeys() {
+        return [this.inputKey]
+    }
+
+    get outputKeys() {
+        return [this.outputKey]
+    }
+
+    constructor(fields: APIChainInput) {
+        super(fields)
+        this.apiRequestChain = fields.apiRequestChain
+        this.apiAnswerChain = fields.apiAnswerChain
+        this.apiDocs = fields.apiDocs
+        this.inputKey = fields.inputKey ?? this.inputKey
+        this.outputKey = fields.outputKey ?? this.outputKey
+        this.headers = fields.headers ?? this.headers
+    }
+
+    /** @ignore */
+    async _call(values: ChainValues, runManager?: CallbackManagerForChainRun): Promise<ChainValues> {
+        try {
+            const question: string = values[this.inputKey]
+
+            const api_url_body = await this.apiRequestChain.predict({ question, api_docs: this.apiDocs }, runManager?.getChild())
+
+            const { url, data } = JSON.parse(api_url_body)
+
+            const res = await fetch(url, {
+                method: 'POST',
+                headers: this.headers,
+                body: JSON.stringify(data)
+            })
+
+            const api_response = await res.text()
+
+            const answer = await this.apiAnswerChain.predict(
+                { question, api_docs: this.apiDocs, api_url_body, api_response },
+                runManager?.getChild()
+            )
+
+            return { [this.outputKey]: answer }
+        } catch (error) {
+            return { [this.outputKey]: error }
+        }
+    }
+
+    _chainType() {
+        return 'api_chain' as const
+    }
+
+    static async deserialize(data: SerializedAPIChain) {
+        const { api_request_chain, api_answer_chain, api_docs } = data
+
+        if (!api_request_chain) {
+            throw new Error('LLMChain must have api_request_chain')
+        }
+        if (!api_answer_chain) {
+            throw new Error('LLMChain must have api_answer_chain')
+        }
+        if (!api_docs) {
+            throw new Error('LLMChain must have api_docs')
+        }
+
+        return new APIChain({
+            apiAnswerChain: await LLMChain.deserialize(api_answer_chain),
+            apiRequestChain: await LLMChain.deserialize(api_request_chain),
+            apiDocs: api_docs
+        })
+    }
+
+    serialize(): SerializedAPIChain {
+        return {
+            _type: this._chainType(),
+            api_answer_chain: this.apiAnswerChain.serialize(),
+            api_request_chain: this.apiRequestChain.serialize(),
+            api_docs: this.apiDocs
+        }
+    }
+
+    static fromLLMAndAPIDocs(
+        llm: BaseLanguageModel,
+        apiDocs: string,
+        options: APIChainOptions & Omit<APIChainInput, 'apiAnswerChain' | 'apiRequestChain' | 'apiDocs'> = {}
+    ): APIChain {
+        const { apiUrlPrompt = defaultApiUrlPrompt, apiResponsePrompt = defaultApiResponsePrompt, outputParser = undefined } = options
+        const apiRequestChain = new LLMChain({ prompt: apiUrlPrompt, llm })
+        // let promptValues = apiResponsePrompt
+        // if (outputParser) {
+        //     promptValues = injectOutputParser(outputParser, apiRequestChain, apiResponsePrompt)
+        // }
+        const apiAnswerChain = new LLMChain({
+            prompt: apiResponsePrompt,
+            llm,
+            outputParser: outputParser as BaseLLMOutputParser<string | object>
+        })
+        return new this({
+            apiAnswerChain,
+            apiRequestChain,
+            apiDocs,
+            ...options
+        })
+    }
+}


### PR DESCRIPTION
**DESCRIPTION**
- Add output parser for API chain (GET and POST)
- The newly chain is in its own node (Parsed + Chain name)
- To fully use this node, please instruct the tool to output the format into desired JSON object

**SCREENSHOT / RECORDING DEMO**
- GET Chain
![image](https://github.com/Covena-AI/flowise/assets/71967041/7bc7eca5-e7d4-4910-9632-d56687344220)
![image](https://github.com/Covena-AI/flowise/assets/71967041/478003cb-67d1-48a2-9665-3dd9d2ef85b8)

- POST Chain
![image](https://github.com/Covena-AI/flowise/assets/71967041/5520247c-26d7-4347-9126-71d1b37f5ee9)
![image](https://github.com/Covena-AI/flowise/assets/71967041/28c1919a-a3a3-4bf5-9f58-3b58f1518a9f)
